### PR TITLE
Fix failed rounded cylinders/, missing lock section in openSCAD 2023

### DIFF
--- a/parametric cage.scad
+++ b/parametric cage.scad
@@ -173,7 +173,7 @@ module make_base() {
 module rounded_cylinder(r,h,n, center=false) {
   zshift = center ? -h/2 : 0;
   dz(zshift) rotate_extrude(convexity=1) {
-    offset(r=n) offset(delta=-n) square([r,h]);
+    offset(r=n - 0.0001) offset(delta=-n) square([r,h]);
     square([n,h]);
   }
 }


### PR DESCRIPTION
I don't pretend to understand why this is necessary, but openscad 2023 does not appear to like (some) fillet offsets for `rotate_extrude`, and the lock section does not render.

Inexplicably, subtracting a tiny amount from the radius allows the cylinders to generate correctly.

This is a huge help, since openscad 2023 supports [fast-csg](https://ochafik.com/jekyll/update/2022/02/09/openscad-fast-csg-contibution.html) allowing a full render in a few seconds, instead of many minutes.

Another (more verbose) option is this: https://github.com/makingweirdthings/parametric-chastity-cage/blob/main/main.scad#L188C1-L202, where two squares at the final size or added, and then two circles at the rounded corners instead of using offset. I'm not sure if there's a significant performance difference, but maybe it's a slightly cleaner approach.